### PR TITLE
Improve HTTPS+TLS explanation, switch from censys.io to crt.sh.

### DIFF
--- a/src/components/banner.js
+++ b/src/components/banner.js
@@ -68,8 +68,10 @@ const Banner = () => (
                 encryption in transit, and force redirects when clients attempt
                 unencrypted access with <strong>http://</strong>.
                 Thanks to <a href="https://certificate.transparency.dev/"> Certificate
-                Transparency</a>, you can <a href="https://search.censys.io/?q=oscal.club">
-                review our current and old certs here</a>.
+                Transparency</a>, you can <a href="https://crt.sh/?q=oscal.club">
+                review our current and old certs here</a>. We uses the Let's Encrypt R3
+                certificate authority, and they update certificates periodically after
+                checking we public DNS records to prove we still own this infrastructure.
               </p>
             </div>
           </div>

--- a/src/components/banner.js
+++ b/src/components/banner.js
@@ -69,9 +69,10 @@ const Banner = () => (
                 unencrypted access with <strong>http://</strong>.
                 Thanks to <a href="https://certificate.transparency.dev/"> Certificate
                 Transparency</a>, you can <a href="https://crt.sh/?q=oscal.club">
-                review our current and old certs here</a>. We uses the Let's Encrypt R3
+                review our current and old certs here</a>. We uses Let's Encrypt R3
                 certificate authority, and they update certificates periodically after
-                checking we public DNS records to prove we still own this infrastructure.
+                checking we maintain public DNS records to prove we still own this
+                infrastructure.
               </p>
             </div>
           </div>


### PR DESCRIPTION
It appears that Censys no longer provides free querying of the certificate transparency log from their website. Also, clarify explanation to sound a little less hand-wavey.