### PR TITLE
Fix Post Order on Blog Post Listing Page

### DIFF
--- a/content/blog-posts/awesome-oscal-now-more-awesome-with-content/index.md
+++ b/content/blog-posts/awesome-oscal-now-more-awesome-with-content/index.md
@@ -1,7 +1,7 @@
 ---
 title: Awesome OSCAL, Now More Awesome with Content!
 date: 2022-09-19T00:46:27.896Z
-author: Al S
+author: Al S (Clubhouse Manager)
 ---
 # What's Happening in the OSCAL World?
 

--- a/content/blog-posts/oscal-is-a-noun-you-bring-the-verbs/index.md
+++ b/content/blog-posts/oscal-is-a-noun-you-bring-the-verbs/index.md
@@ -1,7 +1,7 @@
 ---
 title: OSCAL Is a Noun, You Bring the Verbs
 date: 2022-03-03T01:06:01.571Z
-author: Al S
+author: Al S (Clubhouse Manager)
 ---
 As I watch the OSCAL community expand, I am excited to see an explosive growth in the quantity and quality of OSCAL-based projects. There are many kinds of people involved in OSCAL projects, and I have the wonderful privilege of talking to these many kinds of people, all in different steps of their OSCAL journey. One theme I hear increasingly often from those who have built expertise in OSCAL and get questions from the uninitiated is: **OSCAL is a noun, not a verb, why do people not get that!?**
 

--- a/content/blog-posts/site-redesign.md
+++ b/content/blog-posts/site-redesign.md
@@ -1,6 +1,6 @@
 ---
 title: Site Redesign
-date: February 7, 2022
+date: 2022-02-07T00:00:00.000Z
 author: Al S (Clubhouse Manager)
 ---
 # Breaking News: A New Year, a New Look

--- a/src/templates/blog.js
+++ b/src/templates/blog.js
@@ -196,7 +196,7 @@ export const pageQuery = graphql`
   query($skip: Int!, $limit: Int!) {
     allMarkdownRemark(
       filter: { fields: { sourceName: { eq: "blog-posts" } } }
-      sort: { fields: [frontmatter___date, frontmatter___title], order: ASC }
+      sort: { fields: [frontmatter___date, frontmatter___title], order: DESC }
       skip: $skip
       limit: $limit
     ) {


### PR DESCRIPTION
The GraphQL query for the blog posts was oldest to newest. This needs to be inverted for the blog to go the normal order, with the newest content first.